### PR TITLE
Crash fix

### DIFF
--- a/internal/bot/user.go
+++ b/internal/bot/user.go
@@ -11,6 +11,10 @@ import (
 
 // Create a user from an update
 func createUser(update telegram.Update) *firestore.User {
+	if update.Message == nil {
+		return nil
+	}
+
 	var chatID int64
 	var telegramUser *telegram.User
 


### PR DESCRIPTION
```
stack trace: runtime error: invalid memory address or nil pointer dereference
at runtime/debug.Stack ( /layers/google.go.runtime/go/src/runtime/debug/stack.go:24 )
at github.com/GoogleCloudPlatform/functions-framework-go/funcframework.recoverPanic ( /layers/google.go.functions-framework/gopath/pkg/mod/github.com/!google!cloud!platform/functions-framework-go@v1.8.1/funcframework/framework.go:53 )
at .panic ( /layers/google.go.runtime/go/src/runtime/panic.go:770 )
at github.com/capymind/internal/bot.createUser ( /workspace/serverless_function_source_code/internal/bot/user.go:24 )
at github.com/capymind/internal/bot.Parse ( /workspace/serverless_function_source_code/internal/bot/bot.go:27 )
at github.com/capymind.handler ( /workspace/serverless_function_source_code/function.go:18 )
at github.com/GoogleCloudPlatform/functions-framework-go/funcframework.wrapFunction.wrapHTTPFunction.func1 ( /layers/google.go.functions-framework/gopath/pkg/mod/github.com/!google!cloud!platform/functions-framework-go@v1.8.1/funcframework/framework.go:200 )
at net/http.HandlerFunc.ServeHTTP ( /layers/google.go.runtime/go/src/net/http/server.go:2171 )
at net/http.(*ServeMux).ServeHTTP ( /layers/google.go.runtime/go/src/net/http/server.go:2688 )
at net/http.serverHandler.ServeHTTP ( /layers/google.go.runtime/go/src/net/http/server.go:3142 )
at net/http.(*conn).serve ( /layers/google.go.runtime/go/src/net/http/server.go:2044 )
```